### PR TITLE
ISR IRAM_ATTR

### DIFF
--- a/examples/DFRobotAS3935LightningSensorDetailed/DFRobotAS3935LightningSensorDetailed.ino
+++ b/examples/DFRobotAS3935LightningSensorDetailed/DFRobotAS3935LightningSensorDetailed.ino
@@ -128,7 +128,7 @@ void loop()
 }
 
 //IRQ handler for AS3935 interrupts
-void AS3935_ISR()
+void IRAM_ATTR AS3935_ISR()
 {
   AS3935IsrTrig = 1;
 }

--- a/examples/DFRobotAS3935LightningSensorDetailed/DFRobotAS3935LightningSensorDetailed.ino
+++ b/examples/DFRobotAS3935LightningSensorDetailed/DFRobotAS3935LightningSensorDetailed.ino
@@ -128,7 +128,11 @@ void loop()
 }
 
 //IRQ handler for AS3935 interrupts
+#if defined(ESP32) || defined(ESP8266)
 void IRAM_ATTR AS3935_ISR()
+#else
+void AS3935_ISR()
+#endif
 {
   AS3935IsrTrig = 1;
 }

--- a/examples/DFRobotAS3935LightningSensorOrdinary/DFRobotAS3935LightningSensorOrdinary.ino
+++ b/examples/DFRobotAS3935LightningSensorOrdinary/DFRobotAS3935LightningSensorOrdinary.ino
@@ -106,7 +106,11 @@ void loop()
   }
 }
 //IRQ handler for AS3935 interrupts
+#if defined(ESP32) || defined(ESP8266)
 void IRAM_ATTR AS3935_ISR()
+#else
+void AS3935_ISR()
+#endif
 {
   AS3935IsrTrig = 1;
 }

--- a/examples/DFRobotAS3935LightningSensorOrdinary/DFRobotAS3935LightningSensorOrdinary.ino
+++ b/examples/DFRobotAS3935LightningSensorOrdinary/DFRobotAS3935LightningSensorOrdinary.ino
@@ -106,7 +106,7 @@ void loop()
   }
 }
 //IRQ handler for AS3935 interrupts
-void AS3935_ISR()
+void IRAM_ATTR AS3935_ISR()
 {
   AS3935IsrTrig = 1;
 }


### PR DESCRIPTION
Added "IRAM_ATTR" to ISR for ESP boards, as mentioned here:
https://arduino-esp8266.readthedocs.io/en/latest/reference.html?highlight=IRAM_ATTR#digital-io

Tested for ESP8266, but not for ESP32