### PR TITLE
Update DFRobotAS3935LightningSensorOrdinary.ino

### DIFF
--- a/examples/DFRobotAS3935LightningSensorOrdinary/DFRobotAS3935LightningSensorOrdinary.ino
+++ b/examples/DFRobotAS3935LightningSensorOrdinary/DFRobotAS3935LightningSensorOrdinary.ino
@@ -19,11 +19,9 @@
 
 volatile int8_t AS3935IsrTrig = 0;
 
-#if defined(ESP32) || defined(ESP8266)
-#define IRQ_PIN       0
-#else
+// Connect the license sensor's IRQ pin to a GPIO pin on the microcontroller
+// then replace the number below with the GPIO pin number
 #define IRQ_PIN       2
-#endif
 
 // Antenna tuning capcitance (must be integer multiple of 8, 8 - 120 pf)
 #define AS3935_CAPACITANCE   96


### PR DESCRIPTION
Removed conditional selection of IRQ pins as they dealt with the developer's hardware configuration. Added a comment that explained what the user should do. This simplifies the sample code.